### PR TITLE
add common.Service and core.CoreService inherit it

### DIFF
--- a/common/service.go
+++ b/common/service.go
@@ -1,0 +1,12 @@
+package common
+
+import (
+	"net/http"
+	"net/url"
+)
+
+type Service struct {
+	HTTPClient    *http.Client
+	BaseURL   *url.URL
+	UserAgent string
+}

--- a/common/service.go
+++ b/common/service.go
@@ -5,8 +5,9 @@ import (
 	"net/url"
 )
 
+// Service is base struct
 type Service struct {
-	HTTPClient    *http.Client
-	BaseURL   *url.URL
-	UserAgent string
+	HTTPClient *http.Client
+	BaseURL    *url.URL
+	UserAgent  string
 }

--- a/core/core.go
+++ b/core/core.go
@@ -4,4 +4,5 @@ import (
 	"github.com/zenform/go-zendesk/common"
 )
 
-type CoreService common.Service
+// Service of Core API
+type Service common.Service

--- a/core/core.go
+++ b/core/core.go
@@ -1,33 +1,7 @@
 package core
 
 import (
-	"net/http"
+	"github.com/zenform/go-zendesk/common"
 )
 
-const (
-	// ZendeskDomain is domain of zendesk
-	ZendeskDomain = "zendesk.com"
-
-	// APIRoot is API path including version prefix
-	APIRoot       = ZendeskDomain + "/api/v2"
-)
-
-// APIEndpoint is resource name and API endpoint mapping
-var APIEndpoint = map[string]string{
-	"ticket_form":  APIRoot + "/ticket_forms",
-	"ticket_field": APIRoot + "/ticket_fields",
-	"triggers":     APIRoot + "/triggers",
-}
-
-type CoreAPI struct {
-	client    *http.Client
-	subdomain string
-}
-
-// NewClient create new CoreAPI
-func NewClient(client *http.Client, subdomain string) *CoreAPI {
-	return &CoreAPI{
-		client:    client,
-		subdomain: subdomain,
-	}
-}
+type CoreService common.Service

--- a/core/trigger.go
+++ b/core/trigger.go
@@ -36,6 +36,7 @@ type Trigger struct {
 	UpdatedAt   time.Time       `json:"updated_at"`
 }
 
-func (c *CoreService) GetTriggers() ([]Trigger, error) {
+// GetTriggers fetch trigger list
+func (s *Service) GetTriggers() ([]Trigger, error) {
 	return []Trigger{}, nil
 }

--- a/core/trigger.go
+++ b/core/trigger.go
@@ -35,3 +35,7 @@ type Trigger struct {
 	CreatedAt   time.Time       `json:"created_at"`
 	UpdatedAt   time.Time       `json:"updated_at"`
 }
+
+func (c *CoreService) GetTriggers() ([]Trigger, error) {
+	return []Trigger{}, nil
+}

--- a/zendesk.go
+++ b/zendesk.go
@@ -15,8 +15,9 @@ const (
 	headerRateRemaining = "X-RateLimit-Remaining"
 )
 
+// Client of Zendesk API
 type Client struct {
-	Core *core.CoreService
+	Core *core.Service
 	//TODO: support other APIs
 }
 
@@ -39,7 +40,7 @@ func NewClient(httpClient *http.Client, subdomain string) *Client {
 		UserAgent:  userAgent,
 	}
 
-	client.Core = (*core.CoreService)(service)
+	client.Core = (*core.Service)(service)
 	// other services...
 	return client
 }

--- a/zendesk.go
+++ b/zendesk.go
@@ -1,2 +1,45 @@
 package zendesk
 
+import (
+	"fmt"
+	"github.com/zenform/go-zendesk/common"
+	"github.com/zenform/go-zendesk/core"
+	"net/http"
+	"net/url"
+)
+
+const (
+	baseURLFormat       = "https://%s.zendesk.com/api/v2"
+	userAgent           = "zenform/go-zendesk"
+	headerRateLimit     = "X-RateLimit-Limit"
+	headerRateRemaining = "X-RateLimit-Remaining"
+)
+
+type Client struct {
+	Core *core.CoreService
+	//TODO: support other APIs
+}
+
+// NewClient creates new Zendesk API client
+func NewClient(httpClient *http.Client, subdomain string) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	baseURLString := fmt.Sprintf(baseURLFormat, subdomain)
+	baseURL, err := url.Parse(baseURLString)
+	if err != nil {
+		return nil
+	}
+
+	client := &Client{}
+	service := &common.Service{
+		HTTPClient: httpClient,
+		BaseURL:    baseURL,
+		UserAgent:  userAgent,
+	}
+
+	client.Core = (*core.CoreService)(service)
+	// other services...
+	return client
+}


### PR DESCRIPTION
Any other service must inherit `common.Service` to refer member
- `HTTPClient` : `*http.Client` HTTP client of `net/http`
- `BaseURL` : `*url.URL` Zendesk API URL including subdomain
- `UserAgent` : `string` user-agent of zenform/go-zendesk

```go
package some

import (
    "github.com/zenform/go-zendesk/common"
)

type some.Service common.Service
```