### PR TITLE
unmarshal trigger actions value according to type (string or []string)

### DIFF
--- a/core/trigger.go
+++ b/core/trigger.go
@@ -24,11 +24,15 @@ type TriggerAction struct {
 	Value TriggerActionValue `json:"value"`
 }
 
+// TriggerActionValue is value holder of TriggerAction#Value.
+// This is because type difference of value in JSON response.
 type TriggerActionValue struct {
 	AsString      string
 	AsStringArray []string
 }
 
+// UnmarshalJSON deserialize JSON body to TriggerActionValue
+// according its value type
 func (tav *TriggerActionValue) UnmarshalJSON(data []byte) error {
 	switch string(data)[0] {
 	case '"':

--- a/core/trigger.go
+++ b/core/trigger.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/zenform/go-zendesk/common"
 	"io/ioutil"
 	"net/http"
@@ -19,8 +20,27 @@ type TriggerCondition struct {
 // TriggerAction is zendesk trigger action
 // ref: https://developer.zendesk.com/rest_api/docs/core/triggers#actions
 type TriggerAction struct {
-	Field string `json:"field"`
-	Value string `json:"value"`
+	Field string             `json:"field"`
+	Value TriggerActionValue `json:"value"`
+}
+
+type TriggerActionValue struct {
+	AsString      string
+	AsStringArray []string
+}
+
+func (tav *TriggerActionValue) UnmarshalJSON(data []byte) error {
+	switch string(data)[0] {
+	case '"':
+		if err := json.Unmarshal(data, &tav.AsString); err != nil {
+			fmt.Errorf("failed to unmarshal trigger.action.value as string")
+		}
+	case '[':
+		if err := json.Unmarshal(data, &tav.AsStringArray); err != nil {
+			fmt.Errorf("failed to unmarshal trigger.action.value as []string")
+		}
+	}
+	return nil
 }
 
 // Trigger is zendesk trigger JSON payload format


### PR DESCRIPTION
fix #9 
refer action `value` as below

```go
// string type
action.Value.AsString

// []string type
action.Value.AsStringArray
```

It depends on `field` value which to refer.
